### PR TITLE
Correct CI badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Toolshed.Nerves
 
 [![CircleCI](https://circleci.com/gh/elixir-toolshed/toolshed_nerves.svg?style=svg)](https://circleci.com/gh/elixir-toolshed/toolshed_nerves)
-[![Hex version](https://img.shields.io/hexpm/v/toolshed.svg "Hex version")](https://hex.pm/packages/toolshed_nerves)
+[![Hex version](https://img.shields.io/hexpm/v/toolshed_nerves.svg "Hex version")](https://hex.pm/packages/toolshed_nerves)
 
 <!-- README START -->
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Toolshed.Nerves
 
-[![CircleCI](https://circleci.com/gh/elixir-toolshed/toolshed.svg?style=svg)](https://circleci.com/gh/elixir-toolshed/toolshed_nerves)
+[![CircleCI](https://circleci.com/gh/elixir-toolshed/toolshed_nerves.svg?style=svg)](https://circleci.com/gh/elixir-toolshed/toolshed_nerves)
 [![Hex version](https://img.shields.io/hexpm/v/toolshed.svg "Hex version")](https://hex.pm/packages/toolshed_nerves)
 
 <!-- README START -->


### PR DESCRIPTION
### Description

The badges on README were the ones for `toolshed`.

[![CircleCI](https://circleci.com/gh/elixir-toolshed/toolshed_nerves.svg?style=svg)](https://circleci.com/gh/elixir-toolshed/toolshed_nerves)
Currently CI is failing but it will be resolved once we release a new version of `toolshed` and point this package to it in `mix.exs`.

[![Hex version](https://img.shields.io/hexpm/v/toolshed_nerves.svg "Hex version")](https://hex.pm/packages/toolshed_nerves)
This one should work once we officially publish this package.

