### PR TITLE
Use Toolshed quietly when using Toolshed.Nerves

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Making the IEx console friendlier one command at a time
 
 To use the helpers, run:
 
-    iex> use Toolshed
     iex> use Toolshed.Nerves
 
 Add this to your `.iex.exs` to load automatically.

--- a/lib/toolshed_nerves.ex
+++ b/lib/toolshed_nerves.ex
@@ -7,20 +7,7 @@ defmodule Toolshed.Nerves do
 
   defmacro __using__(_) do
     quote do
-      # Toolshed module is load but not already imported
-      if unquote(Code.ensure_loaded?(Toolshed) and is_nil(__CALLER__.functions[Toolshed])) do
-        IO.warn("""
-        Toolshed is required to be used explicitly before Toolshed.Nerves is used. Instead of:
-
-            use Toolshed.Nerves
-
-        do:
-
-            use Toolshed
-            use Toolshed.Nerves
-        """)
-      end
-
+      use Toolshed, quiet: true
       import Toolshed.Nerves
 
       # If module docs have been stripped, then don't tell the user that they can

--- a/test/toolshed_nerves/dmesg_test.exs
+++ b/test/toolshed_nerves/dmesg_test.exs
@@ -3,7 +3,6 @@ defmodule Toolshed.Nerves.DmesgTest do
   import ExUnit.CaptureIO
 
   test "h/1 macro prints doc" do
-    use Toolshed
     use Toolshed.Nerves
     assert capture_io(fn -> h(dmesg) end) |> String.match?(~r/def dmesg/)
   end

--- a/test/toolshed_nerves/exit_test.exs
+++ b/test/toolshed_nerves/exit_test.exs
@@ -3,7 +3,6 @@ defmodule Toolshed.Nerves.ExitTest do
   import ExUnit.CaptureIO
 
   test "h/1 macro prints doc" do
-    use Toolshed
     use Toolshed.Nerves
     assert capture_io(fn -> h(exit) end) |> String.match?(~r/def exit/)
   end

--- a/test/toolshed_nerves/fw_validate_test.exs
+++ b/test/toolshed_nerves/fw_validate_test.exs
@@ -3,7 +3,6 @@ defmodule Toolshed.Nerves.FwValidateTest do
   import ExUnit.CaptureIO
 
   test "h/1 macro prints doc" do
-    use Toolshed
     use Toolshed.Nerves
     assert capture_io(fn -> h(fw_validate) end) |> String.match?(~r/def fw_validate/)
   end

--- a/test/toolshed_nerves/lsmod_test.exs
+++ b/test/toolshed_nerves/lsmod_test.exs
@@ -3,7 +3,6 @@ defmodule Toolshed.Nerves.LsmodTest do
   import ExUnit.CaptureIO
 
   test "h/1 macro prints doc" do
-    use Toolshed
     use Toolshed.Nerves
     assert capture_io(fn -> h(lsmod) end) |> String.match?(~r/def lsmod/)
   end

--- a/test/toolshed_nerves/reboot!_test.exs
+++ b/test/toolshed_nerves/reboot!_test.exs
@@ -3,7 +3,6 @@ defmodule :"Elixir.Toolshed.Nerves.Reboot!Test" do
   import ExUnit.CaptureIO
 
   test "h/1 macro prints doc" do
-    use Toolshed
     use Toolshed.Nerves
     assert capture_io(fn -> h(reboot!) end) |> String.match?(~r/def reboot!/)
   end

--- a/test/toolshed_nerves/reboot_test.exs
+++ b/test/toolshed_nerves/reboot_test.exs
@@ -3,7 +3,6 @@ defmodule Toolshed.Nerves.RebootTest do
   import ExUnit.CaptureIO
 
   test "h/1 macro prints doc" do
-    use Toolshed
     use Toolshed.Nerves
     assert capture_io(fn -> h(reboot) end) |> String.match?(~r/def reboot/)
   end

--- a/test/toolshed_nerves/uname_test.exs
+++ b/test/toolshed_nerves/uname_test.exs
@@ -3,7 +3,6 @@ defmodule Toolshed.Nerves.UnameTest do
   import ExUnit.CaptureIO
 
   test "h/1 macro prints doc" do
-    use Toolshed
     use Toolshed.Nerves
     assert capture_io(fn -> h(uname) end) |> String.match?(~r/def uname/)
   end

--- a/test/toolshed_nerves_test.exs
+++ b/test/toolshed_nerves_test.exs
@@ -3,7 +3,6 @@ defmodule Toolshed.NervesTest do
   import ExUnit.CaptureIO
 
   test "__using__ imports helper functions" do
-    use Toolshed
     use Toolshed.Nerves
 
     assert __ENV__.functions[Toolshed] == [
@@ -51,19 +50,5 @@ defmodule Toolshed.NervesTest do
              {:reboot!, 0},
              {:uname, 0}
            ]
-  end
-
-  test "print warning message when Toolshed module is load but not already imported" do
-    assert """
-           \e[33mwarning: \e[0mToolshed is required to be used explicitly before Toolshed.Nerves is used. Instead of:
-
-               use Toolshed.Nerves
-
-           do:
-
-               use Toolshed
-               use Toolshed.Nerves
-
-           """ <> _ = capture_io(:standard_error, fn -> use Toolshed.Nerves end)
   end
 end


### PR DESCRIPTION
### Description

Instead of letting the users use both `Toolshed` and `Toolshed.Nerves` explicitly, we decided to implicitly use `Toolshed` when `use Toolshed.Nerves` is invoked.

Using a feature from https://github.com/elixir-toolshed/toolshed/pull/158, we suppress `Toolshed` printing help text.

### Changes

- Invoke `use Toolshed, quiet: true` in `__using__/1`
- Remove the warning for Toolshed module loaded but not already imported
- Update README.md
- Update tests

### Notes

